### PR TITLE
os/arch/platform vars refactored

### DIFF
--- a/files/easyinstall.sh
+++ b/files/easyinstall.sh
@@ -7,41 +7,36 @@
 
 set -ex
 
-KERNEL=$(uname -s)
+OS_NAME=$(uname -s)
 DOWNLOAD_URL="https://download.cuberite.org"
 DOWNLOAD_FILE="Cuberite.tar.gz"
 
-echo "Identifying kernel: $KERNEL"
+echo "Identified platform: $OS_NAME"
 
-if [ "$KERNEL" = "Linux" ]; then
-	PLATFORM=$(uname -m)
+if [ "$OS_NAME" = "Linux" ]; then
+	ARCH_NAME=$(uname -m)
 
-	echo "Identifying platform: $PLATFORM"
+	echo "Identified architecture: $ARCH_NAME"
 
-	case $PLATFORM in
-		"i686") PLATFORM_TAG="linux-i686" ;;
-		"x86_64") PLATFORM_TAG="linux-x86_64" ;;
-		# Assume that all arm devices are a raspi for now.
-		arm*) PLATFORM_TAG="linux-armhf-raspbian"
+	case $ARCH_NAME in
+		"i686")   ARCH_TAG="linux-i686" ;;
+		"x86_64") ARCH_TAG="linux-x86_64" ;;
+		"armv7l") ARCH_TAG="linux-armhf-raspbian"
 	esac
-elif [ "$KERNEL" = "Darwin" ]; then
+elif [ "$OS_NAME" = "Darwin" ]; then
 	# All Darwins we care about are x86_64
-	PLATFORM_TAG="darwin-x86_64"
-#elif [ "$KERNEL" = "FreeBSD" ]; then
-#	DOWNLOADURL="https://builds.cuberite.org/job/Cuberite%20FreeBSD%20x64%20Master/lastSuccessfulBuild/artifact/Cuberite.tar.gz"
+	ARCH_TAG="darwin-x86_64"
 else
-	echo "Unsupported kernel."
+	echo "Unsupported OS: $OS_NAME"
 	exit 1
 fi
 
 
 echo "Downloading precompiled binaries."
-wget --no-check-certificate "$DOWNLOAD_URL/$PLATFORM_TAG/$DOWNLOAD_FILE"
+wget --no-check-certificate "$DOWNLOAD_URL/$ARCH_TAG/$DOWNLOAD_FILE"
 
 echo "Uncompressing tarball."
 tar xzvf $DOWNLOAD_FILE
 echo "Done."
-
-echo "Cuberite is now installed, run using './Cuberite'."
 
 }


### PR DESCRIPTION
`uname -s`  output better defined as Operating system.
`uname -m` is architecture.
A combination of above two is platform identifier/tag.
Wording of output is changed to reflect the fact the temporal difference:
    __identifying__   vs  __identified__
Removed commented out sections of code.
Removed an unnecessary `echo`.